### PR TITLE
charset-normalizer 3.3.2 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "charset-normalizer" %}
-{% set version = "2.0.4" %}
+{% set version = "3.3.2" %}
 
 
 package:
@@ -8,26 +8,23 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/charset-normalizer-{{ version }}.tar.gz
-  sha256: f23667ebe1084be45f6ae0538e4a5a865206544097e4e8bbcacf42cd02a348f3
+  sha256: f30c3cb33b24454a82faecaf01b19c18562b1e89558fb6c56de4d9118a032fd5
 
 build:
   number: 0
-  noarch: python
-  entry_points:
-    - normalizer = charset_normalizer.cli.normalizer:cli_detect
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . --no-deps -vv --no-build-isolation
+  skip: True  # [py<37]
 
 requirements:
   host:
-    - python >=3.5
+    - python
     - pip
   run:
-    - python >=3.5
+    - python
 
 test:
   imports:
     - charset_normalizer
-    - charset_normalizer.assets
   commands:
     - pip check
     - normalizer --help
@@ -37,8 +34,13 @@ test:
 about:
   home: https://github.com/ousret/charset_normalizer
   summary: The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet.
+  description: |
+    A Library that helps you read text from unknown charset encoding. This project is motivated by chardet.
   license: MIT
   license_file: LICENSE
+  license_family: MIT
+  doc_url: https://charset-normalizer.readthedocs.io/
+  dev_url: https://github.com/jawah/charset_normalizer
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,7 @@ test:
     - pip
 
 about:
-  home: https://github.com/ousret/charset_normalizer
+  home: https://github.com/jawah/charset_normalizer
   summary: The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet.
   description: |
     A Library that helps you read text from unknown charset encoding. This project is motivated by chardet.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,19 +12,19 @@ source:
 
 build:
   number: 0
+  noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps -vv --no-build-isolation
   entry_points:
     - normalizer = charset_normalizer.cli:cli_detect
-  skip: True  # [py<37]
 
 requirements:
   host:
-    - python
+    - python >=3.7
     - pip
     - setuptools
     - wheel
   run:
-    - python
+    - python >=3.7
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,6 +13,8 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps -vv --no-build-isolation
+  entry_points:
+    - normalizer = charset_normalizer.cli:cli_detect
   skip: True  # [py<37]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,8 @@ requirements:
   host:
     - python
     - pip
+    - setuptools
+    - wheel
   run:
     - python
 


### PR DESCRIPTION
charset-normalizer 3.3.2 

**Destination channel:** Defaults

### Links

- [PKG-5172]
- dev_url:        https://github.com/Ousret/charset_normalizer/tree/3.3.2
- conda_forge:    https://github.com/conda-forge/charset-normalizer-feedstock/blob/main/recipe/meta.yaml
- pypi:           https://pypi.org/project/charset-normalizer/3.3.2
- pypi inspector: https://inspector.pypi.io/project/charset-normalizer/3.3.2

### Explanation of changes:

- changed entry point
- removed an import


[PKG-5172]: https://anaconda.atlassian.net/browse/PKG-5172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ